### PR TITLE
Fix path for GLTFLoader so background VR loads successfully; fix favicon path, hero width

### DIFF
--- a/GLTFLoader.js
+++ b/GLTFLoader.js
@@ -68,7 +68,7 @@ import {
 	Vector3,
 	VectorKeyframeTrack,
 	sRGBEncoding
-} from "./three.module.js";
+} from "https://xrpackage.org/xrpackage/three.module.js";
 
 var GLTFLoader = ( function () {
 

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ import THREE from 'https://xrpackage.org/xrpackage/three.module.js';
 import {XRPackageEngine, XRPackage} from 'https://xrpackage.org/xrpackage.js';
 // import THREE from 'http://127.0.0.1:3000/xrpackage/three.module.js';
 // import {XRPackageEngine, XRPackage} from 'http://127.0.0.1:3000/xrpackage.js';
-import {GLTFLoader} from 'http://127.0.0.1:3000/xrpackage/GLTFLoader.js';
+import {GLTFLoader} from 'https://xrpackage.org/xrpackage/GLTFLoader.js';
 
 const localVector = new THREE.Vector3();
 const localVector2 = new THREE.Vector3();

--- a/guides.html
+++ b/guides.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <link rel=icon type="image/png" href="favicon.png">
+    <link rel=icon type="image/png" href="favicon.ico">
     <meta name="twitter:image:src" content="https://webaverse.com/logo.svg">
     <meta name="twitter:site" content="@exokitxr">
     <meta name="twitter:card" content="summary">

--- a/index.css
+++ b/index.css
@@ -1438,6 +1438,9 @@ header.unlocking + .main .blocker .button
   align-items: flex-start;
   pointer-events: all;
 }
+.hero .wrap p {
+  width: 100%;
+}
 .hero h1,
 .hero p,
 .hero-buttons
@@ -1457,7 +1460,6 @@ header.unlocking + .main .blocker .button
   font-size: 20px;
 }
 .hero p .hi {
-  // font-family: 'Bangers';
   font-weight: 600;
 }
 .hero-buttons {

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <link rel=icon type="image/png" href="favicon.png">
+    <link rel=icon type="image/png" href="favicon.ico">
     <meta name="twitter:image:src" content="https://webaverse.com/logo.svg">
     <meta name="twitter:site" content="@exokitxr">
     <meta name="twitter:card" content="summary">


### PR DESCRIPTION
Hi! This PR changes the favicon URL to `favicon.ico` rather than `favicon.png` so the logo shows up in the tab bar.

It also updates the path for GLTFLoader to be the remote path, so the website background VR loads successfully now:

![new homepage with VR background](https://user-images.githubusercontent.com/8850830/84271581-2f5cba80-ab24-11ea-8e8f-16dc2b1a446d.png)

(previously there was an error in console for loading GLTFLoader because it was trying to get it from the localhost URL when run locally).

It also makes the width of the main text on the page to fill it's parent, so the black strip extends fully. It basically just makes the bottom black strip extend to the end of the one above it:

![mismatched widths](https://user-images.githubusercontent.com/8850830/84269323-fa9b3400-ab20-11ea-8d0b-cfa5b45488e6.png)
