### PR TITLE
add standards iconography

### DIFF
--- a/index.css
+++ b/index.css
@@ -1441,6 +1441,18 @@ header.unlocking + .main .blocker .button
 .hero .wrap p {
   width: 100%;
 }
+.hero .icons {
+  display: flex;
+  width: 400px;
+  flex-direction: row;
+  align-items: flex-start;
+  pointer-events: all;
+}
+.hero .icons img {
+  max-width: 120px;
+  margin: auto;
+  filter: grayscale(100%);
+}
 .hero h1,
 .hero p,
 .hero-buttons

--- a/index.css
+++ b/index.css
@@ -1441,15 +1441,14 @@ header.unlocking + .main .blocker .button
 .hero .wrap p {
   width: 100%;
 }
-.hero .icons {
+.hero .wrap .standards-icons {
   display: flex;
-  width: 400px;
+  width: 100%;
   flex-direction: row;
   align-items: flex-start;
-  pointer-events: all;
 }
-.hero .icons img {
-  max-width: 120px;
+.hero .wrap .standards-icons img {
+  max-width: 130px;
   margin: auto;
   filter: grayscale(100%);
 }

--- a/index.html
+++ b/index.html
@@ -72,6 +72,11 @@
           <a href="https://xrpackage.org/browse.html" class="hero-button hi">Get augs</a>
           <a href="https://docs.webaverse.com/docs/creating-an-aug" class=hero-button>Create aug</a>
         </div>
+        <div class=icons>
+          <img src="/img/gltf.svg">
+          <img src="/img/vrm.png">
+          <img src="/img/webxr.png">
+        </div>
       </div>
     </div>
     <script src="app.js" type=module></script>

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
           <a href="https://xrpackage.org/browse.html" class="hero-button hi">Get augs</a>
           <a href="https://docs.webaverse.com/docs/creating-an-aug" class=hero-button>Create aug</a>
         </div>
-        <div class=icons>
+        <div class=standards-icons>
           <img src="/img/gltf.svg">
           <img src="/img/vrm.png">
           <img src="/img/webxr.png">


### PR DESCRIPTION
Fixes issue #5 by adding the icons below the aug buttons. 

![icon-screenshot](https://user-images.githubusercontent.com/23684540/84303846-ddf8ff00-ab14-11ea-8b40-75664cf6bf8c.jpg)

