### PR TITLE
Switch to polygon before unsticking.

### DIFF
--- a/components/CardDetails.js
+++ b/components/CardDetails.js
@@ -10,7 +10,14 @@ import Link from "next/link";
 import User from "./User";
 import FileInput from "./FileInput";
 import ViewSwitch from "./ViewSwitch";
-import {getBlockchain, runSidechainTransaction, loginWithMetaMask} from "../webaverse/blockchain.js";
+
+import {
+  getBlockchain,
+  runSidechainTransaction,
+  loginWithMetaMask,
+  switchToPolygon
+} from '../webaverse/blockchain.js'
+
 import {getProfileForCreator} from "../functions/UIStateFunctions";
 import {getAddressProofs, getAddressesFromProofs} from "../functions/Functions";
 import {getData} from "./Asset";
@@ -1215,6 +1222,7 @@ const CardDetails = ({
     
     try {
       const networkName = currentLocation.replace(/\-stuck$/, '');
+      await switchToPolygon();
       const metamaskAddress = await loginWithMetaMask();
       await resubmitAsset(
         networkName,

--- a/components/CardDetails.js
+++ b/components/CardDetails.js
@@ -16,7 +16,7 @@ import {
   runSidechainTransaction,
   loginWithMetaMask,
   switchToPolygon
-} from '../webaverse/blockchain.js'
+} from '../webaverse/blockchain.js';
 
 import {getProfileForCreator} from "../functions/UIStateFunctions";
 import {getAddressProofs, getAddressesFromProofs} from "../functions/Functions";


### PR DESCRIPTION
Should we switch back after the transaction is complete to prevent user confusion? Or would it be better to just ensure the user is always on the correct network before attempting a TX?